### PR TITLE
Feature/update developer dockerfile to support using the developers packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM golang:1.21.1 as builder
+FROM golang:1.22.1 as builder
 WORKDIR /build
 COPY go.mod go.sum ./
+COPY *.go ./
 RUN go mod download
-COPY ./ ./
-RUN go build scratchdata
-EXPOSE 3000
-ENTRYPOINT ["./scratchdata", "local.toml"]
+RUN go build -o scratchdata
+EXPOSE 8080
+ENTRYPOINT ["./scratchdata", "config.yaml"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,14 @@
 FROM golang:1.22.1 as builder
 WORKDIR /build
+# avoiding doing "COPY . ."
+# as that could bake the "data" folder into the image if the operator uses the default config
+VOLUME ["/data"]
+VOLUME ["/config.yaml"]
 COPY go.mod go.sum ./
-COPY *.go ./
+COPY models ./
+COPY pkg ./
 RUN go mod download
-RUN go build -o scratchdata
+RUN go build -o /scratchdata
+RUN chmod +x /scratchdata
 EXPOSE 8080
-ENTRYPOINT ["./scratchdata", "config.yaml"]
+ENTRYPOINT ["/scratchdata", "config.yaml"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,33 @@
+services:
+
+  scratchdb:
+    container_name: scratchdb
+    image: scratchdb
+    build:
+     context: .
+    ports:
+      - "8080:8080"
+
+    volumes:
+        - type: bind
+          read_only: true
+          source: ./config.yaml
+          target: /config.yaml
+
+        - type: bind
+          read_only: false
+          source: ./data
+          target: /data
+
+
+    environment:
+      - PUID=1000
+      - PGID=1000
+      - TZ=America/Chicago
+
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "20m"
+        max-file: "5"
+        mode: "non-blocking"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,11 +20,6 @@ services:
           target: /data
 
 
-    environment:
-      - PUID=1000
-      - PGID=1000
-      - TZ=America/Chicago
-
     logging:
       driver: "json-file"
       options:


### PR DESCRIPTION
Still fiddling with the following error message:

```
 => [scratchdb 1/8] FROM docker.io/library/golang:1.22.1@sha256:0b55ab82ac2a54a6f8f85ec8b943b9e470c39e32c109b76  0.0s
 => [scratchdb internal] load build context                                                                      0.0s
 => => transferring context: 6.47kB                                                                              0.0s
 => CACHED [scratchdb 2/8] WORKDIR /build                                                                        0.0s
 => CACHED [scratchdb 3/8] COPY go.mod go.sum ./                                                                 0.0s
 => CACHED [scratchdb 4/8] COPY models ./                                                                        0.0s
 => CACHED [scratchdb 5/8] COPY pkg ./                                                                           0.0s
 => CACHED [scratchdb 6/8] RUN go mod download                                                                   0.0s
 => [scratchdb 7/8] RUN GOARCH=amd64 GOOS=linux go build -o /scratchdata                                         0.4s
 => [scratchdb 8/8] RUN chmod +x /scratchdata                                                                    0.3s
 => [scratchdb] exporting to image                                                                              13.8s
 => => exporting layers                                                                                         13.8s
 => => writing image sha256:3c3b7d634d0ec7d8f4906bb03767c15d55d6cd84e9dae08450f8982bd6e11484                     0.0s
 => => naming to docker.io/library/scratchdb                                                                     0.0s
[+] Running 0/1
 ⠋ Container scratchdb  Recreated                                                                                0.1s 
Attaching to scratchdb
scratchdb  | exec /scratchdata: exec format error
scratchdb exited with code 1


```